### PR TITLE
Remove noarch python to build for python version under 3.9  

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,22 +8,54 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_sizemd:
-        CONFIG: linux_64_sizemd
+      linux_64_python3.7.____cpythonsizelg:
+        CONFIG: linux_64_python3.7.____cpythonsizelg
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
-      linux_64_sizesm:
-        CONFIG: linux_64_sizesm
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_python3.7.____cpythonsizemd:
+        CONFIG: linux_64_python3.7.____cpythonsizemd
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
-      linux_64_sizelg:
-        CONFIG: linux_64_sizelg
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_python3.7.____cpythonsizesm:
+        CONFIG: linux_64_python3.7.____cpythonsizesm
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
-      linux_64_sizetrf:
-        CONFIG: linux_64_sizetrf
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_python3.7.____cpythonsizetrf:
+        CONFIG: linux_64_python3.7.____cpythonsizetrf
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_python3.8.____cpythonsizelg:
+        CONFIG: linux_64_python3.8.____cpythonsizelg
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_python3.8.____cpythonsizemd:
+        CONFIG: linux_64_python3.8.____cpythonsizemd
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_python3.8.____cpythonsizesm:
+        CONFIG: linux_64_python3.8.____cpythonsizesm
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_python3.8.____cpythonsizetrf:
+        CONFIG: linux_64_python3.8.____cpythonsizetrf
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_python3.9.____cpythonsizelg:
+        CONFIG: linux_64_python3.9.____cpythonsizelg
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_python3.9.____cpythonsizemd:
+        CONFIG: linux_64_python3.9.____cpythonsizemd
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_python3.9.____cpythonsizesm:
+        CONFIG: linux_64_python3.9.____cpythonsizesm
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_python3.9.____cpythonsizetrf:
+        CONFIG: linux_64_python3.9.____cpythonsizetrf
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
   timeoutInMinutes: 360
 
   steps:
@@ -44,6 +76,11 @@ jobs:
         export CI=azure
         export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
         export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
+        if [[ "${BUILD_REASON:-}" == "PullRequest" ]]; then
+          export IS_PR_BUILD="True"
+        else
+          export IS_PR_BUILD="False"
+        fi
         .scripts/run_docker_build.sh
     displayName: Run docker build
     env:

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,17 +8,41 @@ jobs:
     vmImage: macOS-10.15
   strategy:
     matrix:
-      osx_64_sizemd:
-        CONFIG: osx_64_sizemd
+      osx_64_python3.7.____cpythonsizelg:
+        CONFIG: osx_64_python3.7.____cpythonsizelg
         UPLOAD_PACKAGES: 'True'
-      osx_64_sizesm:
-        CONFIG: osx_64_sizesm
+      osx_64_python3.7.____cpythonsizemd:
+        CONFIG: osx_64_python3.7.____cpythonsizemd
         UPLOAD_PACKAGES: 'True'
-      osx_64_sizelg:
-        CONFIG: osx_64_sizelg
+      osx_64_python3.7.____cpythonsizesm:
+        CONFIG: osx_64_python3.7.____cpythonsizesm
         UPLOAD_PACKAGES: 'True'
-      osx_64_sizetrf:
-        CONFIG: osx_64_sizetrf
+      osx_64_python3.7.____cpythonsizetrf:
+        CONFIG: osx_64_python3.7.____cpythonsizetrf
+        UPLOAD_PACKAGES: 'True'
+      osx_64_python3.8.____cpythonsizelg:
+        CONFIG: osx_64_python3.8.____cpythonsizelg
+        UPLOAD_PACKAGES: 'True'
+      osx_64_python3.8.____cpythonsizemd:
+        CONFIG: osx_64_python3.8.____cpythonsizemd
+        UPLOAD_PACKAGES: 'True'
+      osx_64_python3.8.____cpythonsizesm:
+        CONFIG: osx_64_python3.8.____cpythonsizesm
+        UPLOAD_PACKAGES: 'True'
+      osx_64_python3.8.____cpythonsizetrf:
+        CONFIG: osx_64_python3.8.____cpythonsizetrf
+        UPLOAD_PACKAGES: 'True'
+      osx_64_python3.9.____cpythonsizelg:
+        CONFIG: osx_64_python3.9.____cpythonsizelg
+        UPLOAD_PACKAGES: 'True'
+      osx_64_python3.9.____cpythonsizemd:
+        CONFIG: osx_64_python3.9.____cpythonsizemd
+        UPLOAD_PACKAGES: 'True'
+      osx_64_python3.9.____cpythonsizesm:
+        CONFIG: osx_64_python3.9.____cpythonsizesm
+        UPLOAD_PACKAGES: 'True'
+      osx_64_python3.9.____cpythonsizetrf:
+        CONFIG: osx_64_python3.9.____cpythonsizetrf
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
 
@@ -29,6 +53,11 @@ jobs:
       export OSX_FORCE_SDK_DOWNLOAD="1"
       export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
       export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
+      if [[ "${BUILD_REASON:-}" == "PullRequest" ]]; then
+        export IS_PR_BUILD="True"
+      else
+        export IS_PR_BUILD="False"
+      fi
       ./.scripts/run_osx_build.sh
     displayName: Run OSX build
     env:

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -8,17 +8,41 @@ jobs:
     vmImage: vs2017-win2016
   strategy:
     matrix:
-      win_64_sizemd:
-        CONFIG: win_64_sizemd
+      win_64_python3.7.____cpythonsizelg:
+        CONFIG: win_64_python3.7.____cpythonsizelg
         UPLOAD_PACKAGES: 'True'
-      win_64_sizesm:
-        CONFIG: win_64_sizesm
+      win_64_python3.7.____cpythonsizemd:
+        CONFIG: win_64_python3.7.____cpythonsizemd
         UPLOAD_PACKAGES: 'True'
-      win_64_sizelg:
-        CONFIG: win_64_sizelg
+      win_64_python3.7.____cpythonsizesm:
+        CONFIG: win_64_python3.7.____cpythonsizesm
         UPLOAD_PACKAGES: 'True'
-      win_64_sizetrf:
-        CONFIG: win_64_sizetrf
+      win_64_python3.7.____cpythonsizetrf:
+        CONFIG: win_64_python3.7.____cpythonsizetrf
+        UPLOAD_PACKAGES: 'True'
+      win_64_python3.8.____cpythonsizelg:
+        CONFIG: win_64_python3.8.____cpythonsizelg
+        UPLOAD_PACKAGES: 'True'
+      win_64_python3.8.____cpythonsizemd:
+        CONFIG: win_64_python3.8.____cpythonsizemd
+        UPLOAD_PACKAGES: 'True'
+      win_64_python3.8.____cpythonsizesm:
+        CONFIG: win_64_python3.8.____cpythonsizesm
+        UPLOAD_PACKAGES: 'True'
+      win_64_python3.8.____cpythonsizetrf:
+        CONFIG: win_64_python3.8.____cpythonsizetrf
+        UPLOAD_PACKAGES: 'True'
+      win_64_python3.9.____cpythonsizelg:
+        CONFIG: win_64_python3.9.____cpythonsizelg
+        UPLOAD_PACKAGES: 'True'
+      win_64_python3.9.____cpythonsizemd:
+        CONFIG: win_64_python3.9.____cpythonsizemd
+        UPLOAD_PACKAGES: 'True'
+      win_64_python3.9.____cpythonsizesm:
+        CONFIG: win_64_python3.9.____cpythonsizesm
+        UPLOAD_PACKAGES: 'True'
+      win_64_python3.9.____cpythonsizetrf:
+        CONFIG: win_64_python3.9.____cpythonsizetrf
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables:
@@ -61,7 +85,7 @@ jobs:
 
     - task: CondaEnvironment@1
       inputs:
-        packageSpecs: 'python=3.6 conda-build conda "conda-forge-ci-setup=3" pip' # Optional
+        packageSpecs: 'python=3.9 conda-build conda "conda-forge-ci-setup=3" pip boa' # Optional
         installOptions: "-c conda-forge"
         updateConda: true
       displayName: Install conda-build and activate environment
@@ -81,7 +105,7 @@ jobs:
         call activate base
         run_conda_forge_build_setup
       displayName: conda-forge build setup
-
+    
 
     # Special cased version setting some more things!
     - script: |
@@ -95,7 +119,7 @@ jobs:
 
     - script: |
         call activate base
-        conda.exe build "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables
+        conda.exe mambabuild "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables
       displayName: Build recipe
       env:
         PYTHONUNBUFFERED: 1
@@ -116,4 +140,4 @@ jobs:
         BINSTAR_TOKEN: $(BINSTAR_TOKEN)
         FEEDSTOCK_TOKEN: $(FEEDSTOCK_TOKEN)
         STAGING_BINSTAR_TOKEN: $(STAGING_BINSTAR_TOKEN)
-      condition: and(succeeded(), not(eq(variables['UPLOAD_PACKAGES'], 'False')))
+      condition: and(succeeded(), not(eq(variables['UPLOAD_PACKAGES'], 'False')), not(eq(variables['Build.Reason'], 'PullRequest')))

--- a/.ci_support/linux_64_python3.7.____cpythonsizelg.yaml
+++ b/.ci_support/linux_64_python3.7.____cpythonsizelg.yaml
@@ -1,0 +1,18 @@
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.7.* *_cpython
+size:
+- lg
+target_platform:
+- linux-64

--- a/.ci_support/linux_64_python3.7.____cpythonsizemd.yaml
+++ b/.ci_support/linux_64_python3.7.____cpythonsizemd.yaml
@@ -1,21 +1,18 @@
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.7.* *_cpython
 size:
-- sm
+- md
 target_platform:
 - linux-64
-zip_keys:
-- - cdt_name
-  - docker_image

--- a/.ci_support/linux_64_python3.7.____cpythonsizesm.yaml
+++ b/.ci_support/linux_64_python3.7.____cpythonsizesm.yaml
@@ -1,0 +1,18 @@
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.7.* *_cpython
+size:
+- sm
+target_platform:
+- linux-64

--- a/.ci_support/linux_64_python3.7.____cpythonsizetrf.yaml
+++ b/.ci_support/linux_64_python3.7.____cpythonsizetrf.yaml
@@ -1,0 +1,18 @@
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.7.* *_cpython
+size:
+- trf
+target_platform:
+- linux-64

--- a/.ci_support/linux_64_python3.8.____cpythonsizelg.yaml
+++ b/.ci_support/linux_64_python3.8.____cpythonsizelg.yaml
@@ -1,0 +1,18 @@
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+size:
+- lg
+target_platform:
+- linux-64

--- a/.ci_support/linux_64_python3.8.____cpythonsizemd.yaml
+++ b/.ci_support/linux_64_python3.8.____cpythonsizemd.yaml
@@ -1,21 +1,18 @@
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.8.* *_cpython
 size:
 - md
 target_platform:
 - linux-64
-zip_keys:
-- - cdt_name
-  - docker_image

--- a/.ci_support/linux_64_python3.8.____cpythonsizesm.yaml
+++ b/.ci_support/linux_64_python3.8.____cpythonsizesm.yaml
@@ -1,14 +1,18 @@
+cdt_name:
+- cos6
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.8.* *_cpython
 size:
-- trf
+- sm
 target_platform:
-- win-64
+- linux-64

--- a/.ci_support/linux_64_python3.8.____cpythonsizetrf.yaml
+++ b/.ci_support/linux_64_python3.8.____cpythonsizetrf.yaml
@@ -1,0 +1,18 @@
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+size:
+- trf
+target_platform:
+- linux-64

--- a/.ci_support/linux_64_python3.9.____cpythonsizelg.yaml
+++ b/.ci_support/linux_64_python3.9.____cpythonsizelg.yaml
@@ -1,11 +1,11 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
+cdt_name:
+- cos6
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
-macos_machine:
-- x86_64-apple-darwin13.4.0
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -13,6 +13,6 @@ pin_run_as_build:
 python:
 - 3.9.* *_cpython
 size:
-- md
+- lg
 target_platform:
-- osx-64
+- linux-64

--- a/.ci_support/linux_64_python3.9.____cpythonsizemd.yaml
+++ b/.ci_support/linux_64_python3.9.____cpythonsizemd.yaml
@@ -1,0 +1,18 @@
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
+size:
+- md
+target_platform:
+- linux-64

--- a/.ci_support/linux_64_python3.9.____cpythonsizesm.yaml
+++ b/.ci_support/linux_64_python3.9.____cpythonsizesm.yaml
@@ -1,0 +1,18 @@
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
+size:
+- sm
+target_platform:
+- linux-64

--- a/.ci_support/linux_64_python3.9.____cpythonsizetrf.yaml
+++ b/.ci_support/linux_64_python3.9.____cpythonsizetrf.yaml
@@ -1,0 +1,18 @@
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
+size:
+- trf
+target_platform:
+- linux-64

--- a/.ci_support/osx_64_python3.7.____cpythonsizelg.yaml
+++ b/.ci_support/osx_64_python3.7.____cpythonsizelg.yaml
@@ -1,14 +1,18 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
+macos_machine:
+- x86_64-apple-darwin13.4.0
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.7.* *_cpython
 size:
-- md
+- lg
 target_platform:
-- win-64
+- osx-64

--- a/.ci_support/osx_64_python3.7.____cpythonsizemd.yaml
+++ b/.ci_support/osx_64_python3.7.____cpythonsizemd.yaml
@@ -1,0 +1,18 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+macos_machine:
+- x86_64-apple-darwin13.4.0
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.7.* *_cpython
+size:
+- md
+target_platform:
+- osx-64

--- a/.ci_support/osx_64_python3.7.____cpythonsizesm.yaml
+++ b/.ci_support/osx_64_python3.7.____cpythonsizesm.yaml
@@ -1,14 +1,18 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
+macos_machine:
+- x86_64-apple-darwin13.4.0
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.7.* *_cpython
 size:
-- lg
+- sm
 target_platform:
-- win-64
+- osx-64

--- a/.ci_support/osx_64_python3.7.____cpythonsizetrf.yaml
+++ b/.ci_support/osx_64_python3.7.____cpythonsizetrf.yaml
@@ -1,0 +1,18 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+macos_machine:
+- x86_64-apple-darwin13.4.0
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.7.* *_cpython
+size:
+- trf
+target_platform:
+- osx-64

--- a/.ci_support/osx_64_python3.8.____cpythonsizelg.yaml
+++ b/.ci_support/osx_64_python3.8.____cpythonsizelg.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 macos_machine:
@@ -11,8 +11,8 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.8.* *_cpython
 size:
-- trf
+- lg
 target_platform:
 - osx-64

--- a/.ci_support/osx_64_python3.8.____cpythonsizemd.yaml
+++ b/.ci_support/osx_64_python3.8.____cpythonsizemd.yaml
@@ -1,0 +1,18 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+macos_machine:
+- x86_64-apple-darwin13.4.0
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+size:
+- md
+target_platform:
+- osx-64

--- a/.ci_support/osx_64_python3.8.____cpythonsizesm.yaml
+++ b/.ci_support/osx_64_python3.8.____cpythonsizesm.yaml
@@ -1,0 +1,18 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+macos_machine:
+- x86_64-apple-darwin13.4.0
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+size:
+- sm
+target_platform:
+- osx-64

--- a/.ci_support/osx_64_python3.8.____cpythonsizetrf.yaml
+++ b/.ci_support/osx_64_python3.8.____cpythonsizetrf.yaml
@@ -1,14 +1,18 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
+macos_machine:
+- x86_64-apple-darwin13.4.0
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.8.* *_cpython
 size:
-- sm
+- trf
 target_platform:
-- win-64
+- osx-64

--- a/.ci_support/osx_64_python3.9.____cpythonsizelg.yaml
+++ b/.ci_support/osx_64_python3.9.____cpythonsizelg.yaml
@@ -1,11 +1,11 @@
-cdt_name:
-- cos6
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
-docker_image:
-- quay.io/condaforge/linux-anvil-comp7
+macos_machine:
+- x86_64-apple-darwin13.4.0
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -13,9 +13,6 @@ pin_run_as_build:
 python:
 - 3.9.* *_cpython
 size:
-- trf
+- lg
 target_platform:
-- linux-64
-zip_keys:
-- - cdt_name
-  - docker_image
+- osx-64

--- a/.ci_support/osx_64_python3.9.____cpythonsizemd.yaml
+++ b/.ci_support/osx_64_python3.9.____cpythonsizemd.yaml
@@ -1,0 +1,18 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+macos_machine:
+- x86_64-apple-darwin13.4.0
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
+size:
+- md
+target_platform:
+- osx-64

--- a/.ci_support/osx_64_python3.9.____cpythonsizesm.yaml
+++ b/.ci_support/osx_64_python3.9.____cpythonsizesm.yaml
@@ -1,0 +1,18 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+macos_machine:
+- x86_64-apple-darwin13.4.0
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
+size:
+- sm
+target_platform:
+- osx-64

--- a/.ci_support/osx_64_python3.9.____cpythonsizetrf.yaml
+++ b/.ci_support/osx_64_python3.9.____cpythonsizetrf.yaml
@@ -1,0 +1,18 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+macos_machine:
+- x86_64-apple-darwin13.4.0
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
+size:
+- trf
+target_platform:
+- osx-64

--- a/.ci_support/win_64_python3.7.____cpythonsizelg.yaml
+++ b/.ci_support/win_64_python3.7.____cpythonsizelg.yaml
@@ -1,0 +1,14 @@
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.7.* *_cpython
+size:
+- lg
+target_platform:
+- win-64

--- a/.ci_support/win_64_python3.7.____cpythonsizemd.yaml
+++ b/.ci_support/win_64_python3.7.____cpythonsizemd.yaml
@@ -1,0 +1,14 @@
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.7.* *_cpython
+size:
+- md
+target_platform:
+- win-64

--- a/.ci_support/win_64_python3.7.____cpythonsizesm.yaml
+++ b/.ci_support/win_64_python3.7.____cpythonsizesm.yaml
@@ -1,0 +1,14 @@
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.7.* *_cpython
+size:
+- sm
+target_platform:
+- win-64

--- a/.ci_support/win_64_python3.7.____cpythonsizetrf.yaml
+++ b/.ci_support/win_64_python3.7.____cpythonsizetrf.yaml
@@ -1,18 +1,14 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
-macos_machine:
-- x86_64-apple-darwin13.4.0
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.7.* *_cpython
 size:
-- sm
+- trf
 target_platform:
-- osx-64
+- win-64

--- a/.ci_support/win_64_python3.8.____cpythonsizelg.yaml
+++ b/.ci_support/win_64_python3.8.____cpythonsizelg.yaml
@@ -1,0 +1,14 @@
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+size:
+- lg
+target_platform:
+- win-64

--- a/.ci_support/win_64_python3.8.____cpythonsizemd.yaml
+++ b/.ci_support/win_64_python3.8.____cpythonsizemd.yaml
@@ -1,0 +1,14 @@
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+size:
+- md
+target_platform:
+- win-64

--- a/.ci_support/win_64_python3.8.____cpythonsizesm.yaml
+++ b/.ci_support/win_64_python3.8.____cpythonsizesm.yaml
@@ -1,18 +1,14 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
-macos_machine:
-- x86_64-apple-darwin13.4.0
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.8.* *_cpython
 size:
-- lg
+- sm
 target_platform:
-- osx-64
+- win-64

--- a/.ci_support/win_64_python3.8.____cpythonsizetrf.yaml
+++ b/.ci_support/win_64_python3.8.____cpythonsizetrf.yaml
@@ -1,0 +1,14 @@
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+size:
+- trf
+target_platform:
+- win-64

--- a/.ci_support/win_64_python3.9.____cpythonsizelg.yaml
+++ b/.ci_support/win_64_python3.9.____cpythonsizelg.yaml
@@ -1,0 +1,14 @@
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
+size:
+- lg
+target_platform:
+- win-64

--- a/.ci_support/win_64_python3.9.____cpythonsizemd.yaml
+++ b/.ci_support/win_64_python3.9.____cpythonsizemd.yaml
@@ -1,0 +1,14 @@
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
+size:
+- md
+target_platform:
+- win-64

--- a/.ci_support/win_64_python3.9.____cpythonsizesm.yaml
+++ b/.ci_support/win_64_python3.9.____cpythonsizesm.yaml
@@ -1,0 +1,14 @@
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
+size:
+- sm
+target_platform:
+- win-64

--- a/.ci_support/win_64_python3.9.____cpythonsizetrf.yaml
+++ b/.ci_support/win_64_python3.9.____cpythonsizetrf.yaml
@@ -1,11 +1,7 @@
-cdt_name:
-- cos6
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
-docker_image:
-- quay.io/condaforge/linux-anvil-comp7
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -13,9 +9,6 @@ pin_run_as_build:
 python:
 - 3.9.* *_cpython
 size:
-- lg
+- trf
 target_platform:
-- linux-64
-zip_keys:
-- - cdt_name
-  - docker_image
+- win-64

--- a/.gitattributes
+++ b/.gitattributes
@@ -18,6 +18,7 @@ bld.bat text eol=crlf
 .gitignore linguist-generated=true
 .travis.yml linguist-generated=true
 .scripts/* linguist-generated=true
+.woodpecker.yml linguist-generated=true
 LICENSE.txt linguist-generated=true
 README.md linguist-generated=true
 azure-pipelines.yml linguist-generated=true

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @JennaLipscomb @mxr-conda @sodre
+* @FernandezMathieu @JennaLipscomb @mxr-conda @sodre

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -25,7 +25,8 @@ conda-build:
  root-dir: ${FEEDSTOCK_ROOT}/build_artifacts
 
 CONDARC
-BUILD_CMD=build
+GET_BOA=boa
+BUILD_CMD=mambabuild
 
 conda install --yes --quiet "conda-forge-ci-setup=3" conda-build pip ${GET_BOA:-} -c conda-forge
 
@@ -36,6 +37,7 @@ source run_conda_forge_build_setup
 
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+
 
 
 ( endgroup "Configuring conda" ) 2> /dev/null
@@ -62,7 +64,7 @@ else
 
     ( startgroup "Uploading packages" ) 2> /dev/null
 
-    if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
+    if [[ "${UPLOAD_PACKAGES}" != "False" ]] && [[ "${IS_PR_BUILD}" == "False" ]]; then
         upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}"  "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
     fi
 

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -75,12 +75,15 @@ fi
 ( startgroup "Start Docker" ) 2> /dev/null
 
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
+export IS_PR_BUILD="${IS_PR_BUILD:-False}"
+docker pull "${DOCKER_IMAGE}"
 docker run ${DOCKER_RUN_ARGS} \
            -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z,delegated \
            -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z,delegated \
            -e CONFIG \
            -e HOST_USER_ID \
            -e UPLOAD_PACKAGES \
+           -e IS_PR_BUILD \
            -e GIT_BRANCH \
            -e UPLOAD_ON_BRANCH \
            -e CI \
@@ -91,9 +94,9 @@ docker run ${DOCKER_RUN_ARGS} \
            -e BINSTAR_TOKEN \
            -e FEEDSTOCK_TOKEN \
            -e STAGING_BINSTAR_TOKEN \
-           $DOCKER_IMAGE \
+           "${DOCKER_IMAGE}" \
            bash \
-           /home/conda/feedstock_root/${PROVIDER_DIR}/build_steps.sh
+           "/home/conda/feedstock_root/${PROVIDER_DIR}/build_steps.sh"
 
 # verify that the end of the script was reached
 test -f "$DONE_CANARY"

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -9,15 +9,17 @@ MINIFORGE_HOME=${MINIFORGE_HOME:-${HOME}/miniforge3}
 ( startgroup "Installing a fresh version of Miniforge" ) 2> /dev/null
 
 MINIFORGE_URL="https://github.com/conda-forge/miniforge/releases/latest/download"
-MINIFORGE_FILE="Miniforge3-MacOSX-x86_64.sh"
+MINIFORGE_FILE="Miniforge3-MacOSX-$(uname -m).sh"
 curl -L -O "${MINIFORGE_URL}/${MINIFORGE_FILE}"
+rm -rf ${MINIFORGE_HOME}
 bash $MINIFORGE_FILE -b -p ${MINIFORGE_HOME}
 
 ( endgroup "Installing a fresh version of Miniforge" ) 2> /dev/null
 
 ( startgroup "Configuring conda" ) 2> /dev/null
 
-BUILD_CMD=build
+GET_BOA=boa
+BUILD_CMD=mambabuild
 
 source ${MINIFORGE_HOME}/etc/profile.d/conda.sh
 conda activate base
@@ -62,7 +64,7 @@ validate_recipe_outputs "${FEEDSTOCK_NAME}"
 
 ( startgroup "Uploading packages" ) 2> /dev/null
 
-if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
+if [[ "${UPLOAD_PACKAGES}" != "False" ]] && [[ "${IS_PR_BUILD}" == "False" ]]; then
   upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}" ./ ./recipe ./.ci_support/${CONFIG}.yaml
 fi
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About spacy-model-es
 
 Home: https://spacy.io
 
-Package license: CC BY-SA 3.0
+Package license: CC-BY-SA-3.0
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/spacy-model-es-feedstock/blob/master/LICENSE.txt)
 
@@ -16,7 +16,7 @@ Current build status
 
 
 <table>
-
+    
   <tr>
     <td>Azure</td>
     <td>
@@ -29,87 +29,255 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_sizemd</td>
+              <td>linux_64_python3.7.____cpythonsizelg</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6197&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spacy-model-es-feedstock?branchName=master&jobName=linux&configuration=linux_64_sizemd" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spacy-model-es-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.7.____cpythonsizelg" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_sizesm</td>
+              <td>linux_64_python3.7.____cpythonsizemd</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6197&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spacy-model-es-feedstock?branchName=master&jobName=linux&configuration=linux_64_sizesm" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spacy-model-es-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.7.____cpythonsizemd" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_sizelg</td>
+              <td>linux_64_python3.7.____cpythonsizesm</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6197&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spacy-model-es-feedstock?branchName=master&jobName=linux&configuration=linux_64_sizelg" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spacy-model-es-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.7.____cpythonsizesm" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_sizetrf</td>
+              <td>linux_64_python3.7.____cpythonsizetrf</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6197&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spacy-model-es-feedstock?branchName=master&jobName=linux&configuration=linux_64_sizetrf" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spacy-model-es-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.7.____cpythonsizetrf" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_sizemd</td>
+              <td>linux_64_python3.8.____cpythonsizelg</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6197&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spacy-model-es-feedstock?branchName=master&jobName=osx&configuration=osx_64_sizemd" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spacy-model-es-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.8.____cpythonsizelg" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_sizesm</td>
+              <td>linux_64_python3.8.____cpythonsizemd</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6197&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spacy-model-es-feedstock?branchName=master&jobName=osx&configuration=osx_64_sizesm" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spacy-model-es-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.8.____cpythonsizemd" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_sizelg</td>
+              <td>linux_64_python3.8.____cpythonsizesm</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6197&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spacy-model-es-feedstock?branchName=master&jobName=osx&configuration=osx_64_sizelg" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spacy-model-es-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.8.____cpythonsizesm" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_sizetrf</td>
+              <td>linux_64_python3.8.____cpythonsizetrf</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6197&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spacy-model-es-feedstock?branchName=master&jobName=osx&configuration=osx_64_sizetrf" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spacy-model-es-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.8.____cpythonsizetrf" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_sizemd</td>
+              <td>linux_64_python3.9.____cpythonsizelg</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6197&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spacy-model-es-feedstock?branchName=master&jobName=win&configuration=win_64_sizemd" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spacy-model-es-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.9.____cpythonsizelg" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_sizesm</td>
+              <td>linux_64_python3.9.____cpythonsizemd</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6197&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spacy-model-es-feedstock?branchName=master&jobName=win&configuration=win_64_sizesm" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spacy-model-es-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.9.____cpythonsizemd" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_sizelg</td>
+              <td>linux_64_python3.9.____cpythonsizesm</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6197&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spacy-model-es-feedstock?branchName=master&jobName=win&configuration=win_64_sizelg" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spacy-model-es-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.9.____cpythonsizesm" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_sizetrf</td>
+              <td>linux_64_python3.9.____cpythonsizetrf</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6197&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spacy-model-es-feedstock?branchName=master&jobName=win&configuration=win_64_sizetrf" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spacy-model-es-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.9.____cpythonsizetrf" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.7.____cpythonsizelg</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6197&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spacy-model-es-feedstock?branchName=master&jobName=osx&configuration=osx_64_python3.7.____cpythonsizelg" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.7.____cpythonsizemd</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6197&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spacy-model-es-feedstock?branchName=master&jobName=osx&configuration=osx_64_python3.7.____cpythonsizemd" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.7.____cpythonsizesm</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6197&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spacy-model-es-feedstock?branchName=master&jobName=osx&configuration=osx_64_python3.7.____cpythonsizesm" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.7.____cpythonsizetrf</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6197&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spacy-model-es-feedstock?branchName=master&jobName=osx&configuration=osx_64_python3.7.____cpythonsizetrf" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.8.____cpythonsizelg</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6197&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spacy-model-es-feedstock?branchName=master&jobName=osx&configuration=osx_64_python3.8.____cpythonsizelg" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.8.____cpythonsizemd</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6197&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spacy-model-es-feedstock?branchName=master&jobName=osx&configuration=osx_64_python3.8.____cpythonsizemd" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.8.____cpythonsizesm</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6197&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spacy-model-es-feedstock?branchName=master&jobName=osx&configuration=osx_64_python3.8.____cpythonsizesm" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.8.____cpythonsizetrf</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6197&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spacy-model-es-feedstock?branchName=master&jobName=osx&configuration=osx_64_python3.8.____cpythonsizetrf" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.9.____cpythonsizelg</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6197&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spacy-model-es-feedstock?branchName=master&jobName=osx&configuration=osx_64_python3.9.____cpythonsizelg" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.9.____cpythonsizemd</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6197&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spacy-model-es-feedstock?branchName=master&jobName=osx&configuration=osx_64_python3.9.____cpythonsizemd" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.9.____cpythonsizesm</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6197&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spacy-model-es-feedstock?branchName=master&jobName=osx&configuration=osx_64_python3.9.____cpythonsizesm" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.9.____cpythonsizetrf</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6197&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spacy-model-es-feedstock?branchName=master&jobName=osx&configuration=osx_64_python3.9.____cpythonsizetrf" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_python3.7.____cpythonsizelg</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6197&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spacy-model-es-feedstock?branchName=master&jobName=win&configuration=win_64_python3.7.____cpythonsizelg" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_python3.7.____cpythonsizemd</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6197&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spacy-model-es-feedstock?branchName=master&jobName=win&configuration=win_64_python3.7.____cpythonsizemd" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_python3.7.____cpythonsizesm</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6197&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spacy-model-es-feedstock?branchName=master&jobName=win&configuration=win_64_python3.7.____cpythonsizesm" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_python3.7.____cpythonsizetrf</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6197&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spacy-model-es-feedstock?branchName=master&jobName=win&configuration=win_64_python3.7.____cpythonsizetrf" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_python3.8.____cpythonsizelg</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6197&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spacy-model-es-feedstock?branchName=master&jobName=win&configuration=win_64_python3.8.____cpythonsizelg" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_python3.8.____cpythonsizemd</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6197&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spacy-model-es-feedstock?branchName=master&jobName=win&configuration=win_64_python3.8.____cpythonsizemd" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_python3.8.____cpythonsizesm</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6197&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spacy-model-es-feedstock?branchName=master&jobName=win&configuration=win_64_python3.8.____cpythonsizesm" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_python3.8.____cpythonsizetrf</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6197&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spacy-model-es-feedstock?branchName=master&jobName=win&configuration=win_64_python3.8.____cpythonsizetrf" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_python3.9.____cpythonsizelg</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6197&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spacy-model-es-feedstock?branchName=master&jobName=win&configuration=win_64_python3.9.____cpythonsizelg" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_python3.9.____cpythonsizemd</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6197&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spacy-model-es-feedstock?branchName=master&jobName=win&configuration=win_64_python3.9.____cpythonsizemd" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_python3.9.____cpythonsizesm</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6197&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spacy-model-es-feedstock?branchName=master&jobName=win&configuration=win_64_python3.9.____cpythonsizesm" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_python3.9.____cpythonsizetrf</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6197&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/spacy-model-es-feedstock?branchName=master&jobName=win&configuration=win_64_python3.9.____cpythonsizetrf" alt="variant">
                 </a>
               </td>
             </tr>
@@ -125,9 +293,9 @@ Current release info
 
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-spacy--model--es_core_news_lg-green.svg)](https://anaconda.org/conda-forge/spacy-model-es_core_news_lg) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/spacy-model-es_core_news_lg.svg)](https://anaconda.org/conda-forge/spacy-model-es_core_news_lg) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/spacy-model-es_core_news_lg.svg)](https://anaconda.org/conda-forge/spacy-model-es_core_news_lg) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/spacy-model-es_core_news_lg.svg)](https://anaconda.org/conda-forge/spacy-model-es_core_news_lg) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-spacy--model--es_core_news_md-green.svg)](https://anaconda.org/conda-forge/spacy-model-es_core_news_md) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/spacy-model-es_core_news_md.svg)](https://anaconda.org/conda-forge/spacy-model-es_core_news_md) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/spacy-model-es_core_news_md.svg)](https://anaconda.org/conda-forge/spacy-model-es_core_news_md) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/spacy-model-es_core_news_md.svg)](https://anaconda.org/conda-forge/spacy-model-es_core_news_md) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-spacy--model--es_core_news_sm-green.svg)](https://anaconda.org/conda-forge/spacy-model-es_core_news_sm) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/spacy-model-es_core_news_sm.svg)](https://anaconda.org/conda-forge/spacy-model-es_core_news_sm) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/spacy-model-es_core_news_sm.svg)](https://anaconda.org/conda-forge/spacy-model-es_core_news_sm) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/spacy-model-es_core_news_sm.svg)](https://anaconda.org/conda-forge/spacy-model-es_core_news_sm) |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-spacy--model--es_core_news_lg-green.svg)](https://anaconda.org/conda-forge/spacy-model-es_core_news_lg) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/spacy-model-es_core_news_lg.svg)](https://anaconda.org/conda-forge/spacy-model-es_core_news_lg) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/spacy-model-es_core_news_lg.svg)](https://anaconda.org/conda-forge/spacy-model-es_core_news_lg) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/spacy-model-es_core_news_lg.svg)](https://anaconda.org/conda-forge/spacy-model-es_core_news_lg) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-spacy--model--es_dep_news_trf-green.svg)](https://anaconda.org/conda-forge/spacy-model-es_dep_news_trf) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/spacy-model-es_dep_news_trf.svg)](https://anaconda.org/conda-forge/spacy-model-es_dep_news_trf) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/spacy-model-es_dep_news_trf.svg)](https://anaconda.org/conda-forge/spacy-model-es_dep_news_trf) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/spacy-model-es_dep_news_trf.svg)](https://anaconda.org/conda-forge/spacy-model-es_dep_news_trf) |
 
 Installing spacy-model-es
@@ -140,23 +308,24 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `spacy-model-es_core_news_md, spacy-model-es_core_news_sm spacy-model-es_core_news_lg spacy-model-es_dep_news_trf` can be installed with:
+Once the `conda-forge` channel has been enabled, `spacy-model-es_core_news_lg, spacy-model-es_core_news_md, spacy-model-es_core_news_sm, spacy-model-es_dep_news_trf` can be installed with:
 
 ```
-conda install spacy-model-es_core_news_md spacy-model-es_core_news_sm spacy-model-es_core_news_lg spacy-model-es_dep_news_trf
+conda install spacy-model-es_core_news_lg spacy-model-es_core_news_md spacy-model-es_core_news_sm spacy-model-es_dep_news_trf
 ```
 
-It is possible to list all of the versions of `spacy-model-es_core_news_md` available on your platform with:
+It is possible to list all of the versions of `spacy-model-es_core_news_lg` available on your platform with:
 
 ```
-conda search spacy-model-es_core_news_md --channel conda-forge
+conda search spacy-model-es_core_news_lg --channel conda-forge
 ```
 
 
 About conda-forge
 =================
 
-[![Powered by NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](http://numfocus.org)
+[![Powered by
+NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](https://numfocus.org)
 
 conda-forge is a community-led conda channel of installable packages.
 In order to provide high-quality builds, the process has been automated into the
@@ -216,6 +385,8 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
+* [@FernandezMathieu](https://github.com/FernandezMathieu/)
 * [@JennaLipscomb](https://github.com/JennaLipscomb/)
 * [@mxr-conda](https://github.com/mxr-conda/)
 * [@sodre](https://github.com/sodre/)
+

--- a/build-locally.py
+++ b/build-locally.py
@@ -13,6 +13,7 @@ import platform
 def setup_environment(ns):
     os.environ["CONFIG"] = ns.config
     os.environ["UPLOAD_PACKAGES"] = "False"
+    os.environ["IS_PR_BUILD"] = "True"
     if ns.debug:
         os.environ["BUILD_WITH_CONDA_DEBUG"] = "1"
         if ns.output_id:
@@ -20,6 +21,10 @@ def setup_environment(ns):
     if "MINIFORGE_HOME" not in os.environ:
         os.environ["MINIFORGE_HOME"] = os.path.join(
             os.path.dirname(__file__), "miniforge3"
+        )
+    if "OSX_SDK_DIR" not in os.environ:
+        os.environ["OSX_SDK_DIR"] = os.path.join(
+            os.path.dirname(__file__), "SDKs"
         )
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,7 @@ source:
 
 build:
   number: 0
+  script: python -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,6 @@ source:
 
 build:
   number: 0
-  script: python -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
 
 test:
   commands:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
